### PR TITLE
Document elastic_profile_id for job

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Please note:
   "name": "test",
   "run_instance_count" : null,
   "environment_variables": [],
+  "timeout": 180,
+  "elastic_profile_id": "docker-big-image-1",
   "tabs": [
      {
        "name": "test",


### PR DESCRIPTION
This documents elastic_profile_id and timeout at the job level. Based on [this code](https://github.com/gocd/gocd/blob/3ba759eb2c6b5883eb207068aba2140298716d82/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java#L16-L18).