### PR TITLE
Add export content metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.thoughtworks.go'
-version = '0.3.3'
+version = '0.3.4'
 
 apply plugin: 'java'
 

--- a/src/com.tw.go.config.json/JsonConfigPlugin.java
+++ b/src/com.tw.go.config.json/JsonConfigPlugin.java
@@ -138,9 +138,13 @@ public class JsonConfigPlugin implements GoPlugin, ConfigRepoMessages {
             ParsedRequest parsed = ParsedRequest.parse(request);
 
             Map<String, Object> pipeline = parsed.getParam("pipeline");
+            String name = (String) pipeline.get("name");
 
-            return success(gson.toJson(Collections.singletonMap("pipeline", prettyPrint.toJson(pipeline))));
+            DefaultGoPluginApiResponse response = success(gson.toJson(Collections.singletonMap("pipeline", prettyPrint.toJson(pipeline))));
 
+            response.addResponseHeader("Content-Type", "application/json; charset=utf-8");
+            response.addResponseHeader("X-Export-Filename", name + ".gopipeline.json");
+            return response;
         });
     }
 


### PR DESCRIPTION
Adds response headers to the API to give hints about the response payload (i.e., exported content):

  - `Content-Type`: self-explanatory
  - `X-Export-Filename`: non-standard header to suggest a filename for the content. This will be used to construct `Content-Disposition` in GoCD's new pipeline export links.
    - _Why not use `Content-Disposition` directly?_ Firstly, this is a matter of opinion, and I'm open to alternatives. So here's the explanation: In GoCD, we really only want to know how to name the file we construct for pipeline export, so I didn't want to open the door for supporting other aspects of `Content-Disposition` from the plugin side (i.e., `attachment` vs `inline` vs `form-data` -- we just want the `; filename=XXX` segment). On the GoCD side, we will use this header to enforce a `Content-Disposition: attachment; filename=<header value goes here>` on GoCD's public REST APIs.

Thoughts @tomzo @arvindsv?