### PR TITLE
Fix absolute paths and file descriptor refs in CLI

### DIFF
--- a/src/com.tw.go.config.json/cli/JsonPluginCli.java
+++ b/src/com.tw.go.config.json/cli/JsonPluginCli.java
@@ -72,7 +72,7 @@ public class JsonPluginCli {
     private static InputStream getFileAsStream(String file) {
         InputStream s = null;
         try {
-            s = "-".equals(file) ? System.in : new FileInputStream(new File(".", file));
+            s = "-".equals(file) ? System.in : new FileInputStream(new File(file));
         } catch (FileNotFoundException e) {
             die(1, e.getMessage());
         }


### PR DESCRIPTION
No need to prepend "." to files
  - redundant for rel paths
  - breaks abs paths (and ad-hoc file descriptor args, e.g. /dev/fd/XX)