### PR TITLE
Implement `parse-content` response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 group = 'com.thoughtworks.go'
-version = '0.3.2'
+version = '0.3.3'
 
 apply plugin: 'java'
 
 project.ext.pluginDesc = [
         version    : project.version,
-        goCdVersion: '18.11.0'
+        goCdVersion: '18.12.0'
 ]
 
 sourceCompatibility = 1.8

--- a/src/com.tw.go.config.json/Capabilities.java
+++ b/src/com.tw.go.config.json/Capabilities.java
@@ -2,9 +2,11 @@ package com.tw.go.config.json;
 
 public class Capabilities {
     private boolean supportsPipelineExport;
+    private boolean supportsParseContent;
 
     public Capabilities() {
         this.supportsPipelineExport = true;
+        this.supportsParseContent = true;
     }
 
     public boolean isSupportsPipelineExport() {
@@ -13,5 +15,13 @@ public class Capabilities {
 
     public void setSupportsPipelineExport(boolean supportsPipelineExport) {
         this.supportsPipelineExport = supportsPipelineExport;
+    }
+
+    public boolean isSupportsParseContent() {
+        return supportsParseContent;
+    }
+
+    public void setSupportsParseContent(boolean supportsParseContent) {
+        this.supportsParseContent = supportsParseContent;
     }
 }

--- a/src/com.tw.go.config.json/ConfigRepoMessages.java
+++ b/src/com.tw.go.config.json/ConfigRepoMessages.java
@@ -7,5 +7,6 @@ public interface ConfigRepoMessages {
     String REQ_PLUGIN_SETTINGS_GET_VIEW = "go.plugin-settings.get-view";
     String REQ_PLUGIN_SETTINGS_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";
     String REQ_PARSE_DIRECTORY = "parse-directory";
+    String REQ_PARSE_CONTENT = "parse-content";
     String REQ_PIPELINE_EXPORT = "pipeline-export";
 }

--- a/src/com.tw.go.config.json/FilenameMatcher.java
+++ b/src/com.tw.go.config.json/FilenameMatcher.java
@@ -1,0 +1,47 @@
+package com.tw.go.config.json;
+
+import org.apache.tools.ant.types.selectors.SelectorUtils;
+
+import java.io.File;
+
+/**
+ * Convenience class that matches the filename only (not full paths) against
+ * pipeline and environment patterns.
+ */
+class FilenameMatcher {
+    private final String pipelineFilePattern;
+    private final String environmentFilePattern;
+
+    FilenameMatcher(PluginSettings config) {
+        pipelineFilePattern = basename(config.getPipelinePattern());
+        environmentFilePattern = basename(config.getEnvironmentPattern());
+    }
+
+    /**
+     * @param pathPattern the path-matching pattern
+     * @return a pattern that only matches the filename (i.e., basename)
+     */
+    private static String basename(String pathPattern) {
+        return new File(normalizePattern(pathPattern)).getName();
+    }
+
+    /**
+     * Ripped from {@link org.apache.tools.ant.DirectoryScanner}
+     */
+    private static String normalizePattern(String p) {
+        String pattern = p.replace('/', File.separatorChar)
+                .replace('\\', File.separatorChar);
+        if (pattern.endsWith(File.separator)) {
+            pattern += "**";
+        }
+        return pattern;
+    }
+
+    boolean isPipelineFile(String filename) {
+        return SelectorUtils.match(pipelineFilePattern, filename);
+    }
+
+    boolean isEnvironmentFile(String filename) {
+        return SelectorUtils.match(environmentFilePattern, filename);
+    }
+}

--- a/src/com.tw.go.config.json/JsonConfigHelper.java
+++ b/src/com.tw.go.config.json/JsonConfigHelper.java
@@ -2,15 +2,14 @@ package com.tw.go.config.json;
 
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
 import com.thoughtworks.go.plugin.api.request.GoApiRequest;
-import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 import java.util.Map;
 
-public class JsonConfigHelper {
+class JsonConfigHelper {
     private JsonConfigHelper() {
     }
 
-    public static GoApiRequest request(final String api, final String responseBody, GoPluginIdentifier identifier) {
+    static GoApiRequest request(final String api, final String responseBody, GoPluginIdentifier identifier) {
         return new GoApiRequest() {
             @Override
             public String api() {
@@ -42,25 +41,5 @@ public class JsonConfigHelper {
                 return responseBody;
             }
         };
-    }
-
-    static GoPluginApiResponse response(final int responseCode, final String json) {
-        return new GoPluginApiResponse() {
-            @Override
-            public int responseCode() {
-                return responseCode;
-            }
-
-            @Override
-            public Map<String, String> responseHeaders() {
-                return null;
-            }
-
-            @Override
-            public String responseBody() {
-                return json;
-            }
-        };
-
     }
 }

--- a/src/com.tw.go.config.json/PluginSettings.java
+++ b/src/com.tw.go.config.json/PluginSettings.java
@@ -1,31 +1,30 @@
 package com.tw.go.config.json;
 
-public class PluginSettings {
+class PluginSettings {
+    static final String DEFAULT_PIPELINE_PATTERN = "**/*.gopipeline.json";
+    static final String DEFAULT_ENVIRONMENT_PATTERN = "**/*.goenvironment.json";
+
     private String pipelinePattern;
     private String environmentPattern;
 
-    public PluginSettings()
-    {
+    PluginSettings() {
+        this(DEFAULT_PIPELINE_PATTERN, DEFAULT_ENVIRONMENT_PATTERN);
     }
-    public PluginSettings(String pipelinePattern,String environmentPattern)
-    {
+
+    PluginSettings(String pipelinePattern, String environmentPattern) {
         this.pipelinePattern = pipelinePattern;
         this.environmentPattern = environmentPattern;
     }
 
-    public String getPipelinePattern() {
-        return pipelinePattern;
+    private static boolean isBlank(String pattern) {
+        return pattern == null || pattern.trim().isEmpty();
     }
 
-    public void setPipelinePattern(String pipelinePattern) {
-        this.pipelinePattern = pipelinePattern;
+    String getPipelinePattern() {
+        return isBlank(pipelinePattern) ? DEFAULT_PIPELINE_PATTERN : pipelinePattern;
     }
 
-    public String getEnvironmentPattern() {
-        return environmentPattern;
-    }
-
-    public void setEnvironmentPattern(String environmentPattern) {
-        this.environmentPattern = environmentPattern;
+    String getEnvironmentPattern() {
+        return isBlank(environmentPattern) ? DEFAULT_ENVIRONMENT_PATTERN : environmentPattern;
     }
 }

--- a/test/com.tw.go.config.json/ConfigDirectoryParserTest.java
+++ b/test/com.tw.go.config.json/ConfigDirectoryParserTest.java
@@ -29,8 +29,8 @@ public class ConfigDirectoryParserTest {
 
         parser = new ConfigDirectoryParser(
                 new AntDirectoryScanner(), new JsonConfigParser(),
-                JsonConfigPlugin.DEFAULT_PIPELINE_PATTERN,
-                JsonConfigPlugin.DEFAULT_ENVIRONMENT_PATTERN);
+                PluginSettings.DEFAULT_PIPELINE_PATTERN,
+                PluginSettings.DEFAULT_ENVIRONMENT_PATTERN);
 
         FileUtils.forceMkdir(directory);
 

--- a/test/com.tw.go.config.json/JsonConfigPluginTest.java
+++ b/test/com.tw.go.config.json/JsonConfigPluginTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -56,7 +57,16 @@ public class JsonConfigPluginTest {
     public void respondsToParseContentRequest() throws Exception {
         final Gson gson = new Gson();
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PARSE_CONTENT);
-        request.setRequestBody(gson.toJson(Collections.singletonMap("content", "{\"name\": \"a\", \"stages\":[]}")));
+
+        request.setRequestBody(gson.toJson(
+                Collections.singletonMap("contents",
+                        Arrays.asList(
+                                Collections.singletonMap("foo.gopipeline.json", "{\"name\": \"a\", \"stages\":[]}"),
+                                Collections.singletonMap("foo.goenvironment.json", "{\"name\": \"b\"}")
+                        )
+                )
+        ));
+
         GoPluginApiResponse response = plugin.handle(request);
         JsonObject jsonObjectFromResponse = getJsonObjectFromResponse(response);
         assertEquals(SUCCESS_RESPONSE_CODE, response.responseCode());
@@ -65,15 +75,23 @@ public class JsonConfigPluginTest {
         JsonObject expected = new JsonObject();
 
         JsonArray pipelines = new JsonArray();
+        JsonArray envs = new JsonArray();
+
         expected.add("errors", new JsonArray());
-        expected.add("environments", new JsonArray());
+        expected.add("environments", envs);
         expected.add("pipelines", pipelines);
         expected.addProperty("target_version", 1);
+
         JsonObject p1 = new JsonObject();
         p1.addProperty("name", "a");
         p1.add("stages", new JsonArray());
-        p1.addProperty("location", "content");
+        p1.addProperty("location", "foo.gopipeline.json");
         pipelines.add(p1);
+
+        JsonObject e1 = new JsonObject();
+        e1.addProperty("name", "b");
+        e1.addProperty("location", "foo.goenvironment.json");
+        envs.add(e1);
 
         assertEquals(expected, jsonObjectFromResponse);
     }

--- a/test/com.tw.go.config.json/JsonConfigPluginTest.java
+++ b/test/com.tw.go.config.json/JsonConfigPluginTest.java
@@ -18,8 +18,11 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 
+import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
+import static com.tw.go.config.json.ConfigRepoMessages.REQ_PARSE_CONTENT;
 import static java.lang.String.format;
 import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
@@ -49,13 +52,38 @@ public class JsonConfigPluginTest {
         FileUtils.forceMkdir(emptyDir);
     }
 
+    @Test
+    public void respondsToParseContentRequest() throws Exception {
+        final Gson gson = new Gson();
+        DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("configrepo", "2.0", REQ_PARSE_CONTENT);
+        request.setRequestBody(gson.toJson(Collections.singletonMap("content", "{\"name\": \"a\", \"stages\":[]}")));
+        GoPluginApiResponse response = plugin.handle(request);
+        JsonObject jsonObjectFromResponse = getJsonObjectFromResponse(response);
+        assertEquals(SUCCESS_RESPONSE_CODE, response.responseCode());
+        assertEquals(new JsonArray(), jsonObjectFromResponse.get("errors"));
+
+        JsonObject expected = new JsonObject();
+
+        JsonArray pipelines = new JsonArray();
+        expected.add("errors", new JsonArray());
+        expected.add("environments", new JsonArray());
+        expected.add("pipelines", pipelines);
+        expected.addProperty("target_version", 1);
+        JsonObject p1 = new JsonObject();
+        p1.addProperty("name", "a");
+        p1.add("stages", new JsonArray());
+        p1.addProperty("location", "content");
+        pipelines.add(p1);
+
+        assertEquals(expected, jsonObjectFromResponse);
+    }
 
     @Test
     public void shouldRespondSuccessToGetConfigurationRequest() throws UnhandledRequestTypeException {
         DefaultGoPluginApiRequest getConfigRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "go.plugin-settings.get-configuration");
 
         GoPluginApiResponse response = plugin.handle(getConfigRequest);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
     }
 
     @Test
@@ -63,7 +91,7 @@ public class JsonConfigPluginTest {
         DefaultGoPluginApiRequest getConfigRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "go.plugin-settings.get-configuration");
 
         GoPluginApiResponse response = plugin.handle(getConfigRequest);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
         JsonObject responseJsonObject = getJsonObjectFromResponse(response);
         JsonElement environmentPatternConfig = responseJsonObject.get("environment_pattern");
         assertNotNull(environmentPatternConfig);
@@ -80,7 +108,7 @@ public class JsonConfigPluginTest {
         DefaultGoPluginApiRequest getConfigRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "go.plugin-settings.get-configuration");
 
         GoPluginApiResponse response = plugin.handle(getConfigRequest);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
         JsonObject responseJsonObject = getJsonObjectFromResponse(response);
         JsonElement pipelinePatternConfig = responseJsonObject.get("pipeline_pattern");
         assertNotNull(pipelinePatternConfig);
@@ -102,7 +130,7 @@ public class JsonConfigPluginTest {
         DefaultGoPluginApiRequest getConfigRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "go.plugin-settings.get-view");
 
         GoPluginApiResponse response = plugin.handle(getConfigRequest);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
     }
 
     @Test
@@ -110,7 +138,7 @@ public class JsonConfigPluginTest {
         DefaultGoPluginApiRequest validateRequest = new DefaultGoPluginApiRequest("configrepo", "1.0", "go.plugin-settings.validate-configuration");
 
         GoPluginApiResponse response = plugin.handle(validateRequest);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
     }
 
     @Test
@@ -123,7 +151,7 @@ public class JsonConfigPluginTest {
         parseDirectoryRequest.setRequestBody(requestBody);
 
         GoPluginApiResponse response = plugin.handle(parseDirectoryRequest);
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
         JsonObject responseJsonObject = getJsonObjectFromResponse(response);
         assertNull(responseJsonObject.get("pluginErrors"));
     }
@@ -182,7 +210,7 @@ public class JsonConfigPluginTest {
         GoPluginApiResponse response = plugin.handle(parseDirectoryRequest);
 
         verify(goAccessor, times(1)).submit(any(GoApiRequest.class));
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
     }
 
     @Test
@@ -201,7 +229,7 @@ public class JsonConfigPluginTest {
 
         GoPluginApiResponse response = plugin.handle(pipelineExportRequest);
 
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
         Gson pretty = new GsonBuilder().setPrettyPrinting().create();
         String prettyPrinted = pretty.toJson(pipeline);
         assertThat(response.responseBody(), is(gson.toJson(Collections.singletonMap("pipeline", prettyPrinted))));
@@ -214,7 +242,7 @@ public class JsonConfigPluginTest {
 
         GoPluginApiResponse response = plugin.handle(request);
 
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
         assertThat(response.responseBody(), is(expected));
     }
 
@@ -233,7 +261,7 @@ public class JsonConfigPluginTest {
         GoPluginApiResponse response = plugin.handle(parseDirectoryRequest);
 
         verify(goAccessor, times(1)).submit(any(GoApiRequest.class));
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
     }
 
     @Test
@@ -250,7 +278,7 @@ public class JsonConfigPluginTest {
 
         GoPluginApiResponse response = plugin.handle(parseDirectoryRequest);
 
-        assertThat(response.responseCode(), is(DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE));
+        assertThat(response.responseCode(), is(SUCCESS_RESPONSE_CODE));
         final JsonParser parser = new JsonParser();
         JsonElement responseObj = parser.parse(response.responseBody());
         assertTrue(responseObj.isJsonObject());


### PR DESCRIPTION
`parse-content` has a similar output to `parse-directory`, but has a completely different input; it takes an array of `filename => content` pairs which will be parsed according to pipeline or environment pattern matching.