### PR TITLE
Fix plugin settings request and implement handler for plugin config change notification

### DIFF
--- a/src/com.tw.go.config.json/ConfigRepoMessages.java
+++ b/src/com.tw.go.config.json/ConfigRepoMessages.java
@@ -3,6 +3,7 @@ package com.tw.go.config.json;
 public interface ConfigRepoMessages {
     String REQ_GET_PLUGIN_SETTINGS = "go.processor.plugin-settings.get";
     String REQ_GET_CAPABILITIES = "get-capabilities";
+    String REQ_PLUGIN_SETTINGS_CHANGED = "go.plugin-settings.plugin-settings-changed";
     String REQ_PLUGIN_SETTINGS_GET_CONFIGURATION = "go.plugin-settings.get-configuration";
     String REQ_PLUGIN_SETTINGS_GET_VIEW = "go.plugin-settings.get-view";
     String REQ_PLUGIN_SETTINGS_VALIDATE_CONFIGURATION = "go.plugin-settings.validate-configuration";

--- a/src/com.tw.go.config.json/FilenameMatcher.java
+++ b/src/com.tw.go.config.json/FilenameMatcher.java
@@ -12,9 +12,9 @@ class FilenameMatcher {
     private final String pipelineFilePattern;
     private final String environmentFilePattern;
 
-    FilenameMatcher(PluginSettings config) {
-        pipelineFilePattern = basename(config.getPipelinePattern());
-        environmentFilePattern = basename(config.getEnvironmentPattern());
+    FilenameMatcher(String pipelineFilePattern, String environmentFilePattern) {
+        this.pipelineFilePattern = basename(pipelineFilePattern);
+        this.environmentFilePattern = basename(environmentFilePattern);
     }
 
     /**

--- a/src/com.tw.go.config.json/JsonConfigHelper.java
+++ b/src/com.tw.go.config.json/JsonConfigHelper.java
@@ -18,7 +18,7 @@ class JsonConfigHelper {
 
             @Override
             public String apiVersion() {
-                return "2.0";
+                return "1.0";
             }
 
             @Override

--- a/src/com.tw.go.config.json/PluginSettings.java
+++ b/src/com.tw.go.config.json/PluginSettings.java
@@ -1,8 +1,12 @@
 package com.tw.go.config.json;
 
+import java.util.Map;
+
 class PluginSettings {
     static final String DEFAULT_PIPELINE_PATTERN = "**/*.gopipeline.json";
     static final String DEFAULT_ENVIRONMENT_PATTERN = "**/*.goenvironment.json";
+    static final String PLUGIN_SETTINGS_PIPELINE_PATTERN = "pipeline_pattern";
+    static final String PLUGIN_SETTINGS_ENVIRONMENT_PATTERN = "environment_pattern";
 
     private String pipelinePattern;
     private String environmentPattern;
@@ -16,15 +20,19 @@ class PluginSettings {
         this.environmentPattern = environmentPattern;
     }
 
-    private static boolean isBlank(String pattern) {
-        return pattern == null || pattern.trim().isEmpty();
+    static PluginSettings fromJson(String json) {
+        Map<String, String> raw = JSONUtils.fromJSON(json);
+        return new PluginSettings(
+                raw.get(PLUGIN_SETTINGS_PIPELINE_PATTERN),
+                raw.get(PLUGIN_SETTINGS_ENVIRONMENT_PATTERN));
+
     }
 
     String getPipelinePattern() {
-        return isBlank(pipelinePattern) ? DEFAULT_PIPELINE_PATTERN : pipelinePattern;
+        return pipelinePattern;
     }
 
     String getEnvironmentPattern() {
-        return isBlank(environmentPattern) ? DEFAULT_ENVIRONMENT_PATTERN : environmentPattern;
+        return environmentPattern;
     }
 }


### PR DESCRIPTION
Since the initial pipeline export work, we have been sending the wrong api version when
fetching plugin settings. This was causing some issues during parse directory. The general
move to extension v2 also caused some issues during plugin load. This PR resolves this.

@tomzo this needs to be merged, or else we'll be shipping broken plugins :/