### PR TITLE
We should always return CLI results as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Follow the steps on [https://github.com/gocd-contrib/gocd-cli](https://github.co
 Then:
 
 ```bash
-./gocd configrepo check -i json.config.plugin /path/to/your-pipeline.gopipeline.json
+./gocd configrepo syntax -i json.config.plugin /path/to/your-pipeline.gopipeline.json
 ```
 
 ## Usage with IDE and docker

--- a/src/com.tw.go.config.json/cli/JsonPluginCli.java
+++ b/src/com.tw.go.config.json/cli/JsonPluginCli.java
@@ -20,7 +20,7 @@ public class JsonPluginCli {
         SyntaxCmd syntax = new SyntaxCmd();
 
         JCommander cmd = JCommander.newBuilder().
-                programName("yaml-cli").
+                programName("json-cli").
                 addObject(root).
                 addCommand("syntax", syntax).
                 build();
@@ -59,9 +59,10 @@ public class JsonPluginCli {
         result.remove("pipelines");
 
         if (collection.getErrors().size() > 0) {
+            result.addProperty("valid", false);
             die(1, result.toString());
         } else {
-            die(0, "OK");
+            die(0, "{\"valid\":true}");
         }
     }
 


### PR DESCRIPTION
@tomzo One last (tiny) PR before cutting a stable release.

This is for the CLI output from the plugin jar; wanted to be consistent and always output JSON. The GoCD CLI should handle the presentation to the user.