### PR TITLE
Adding CR Contract dependency, and use for export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compile group: 'com.beust', name: 'jcommander', version: '1.72'
 
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginDesc.goCdVersion
+    compileOnly group: 'cd.go.plugin', name: 'go-plugin-config-repo', version: project.pluginDesc.goCdVersion
+    testCompile group: 'cd.go.plugin', name: 'go-plugin-config-repo', version: project.pluginDesc.goCdVersion
     testCompile group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginDesc.goCdVersion
 
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java'
 
 project.ext.pluginDesc = [
         version    : project.version,
-        goCdVersion: '18.12.0'
+        goCdVersion: '19.1.0'
 ]
 
 sourceCompatibility = 1.8

--- a/src/com.tw.go.config.json/JsonConfigPlugin.java
+++ b/src/com.tw.go.config.json/JsonConfigPlugin.java
@@ -15,6 +15,7 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
 import org.apache.commons.io.IOUtils;
 
 import java.io.ByteArrayInputStream;
@@ -168,8 +169,8 @@ public class JsonConfigPlugin implements GoPlugin, ConfigRepoMessages {
         return handlingErrors(() -> {
             ParsedRequest parsed = ParsedRequest.parse(request);
 
-            Map<String, Object> pipeline = parsed.getParam("pipeline");
-            String name = (String) pipeline.get("name");
+            CRPipeline pipeline = parsed.getParam("pipeline", CRPipeline.class);
+            String name = pipeline.getName();
 
             DefaultGoPluginApiResponse response = success(gson.toJson(Collections.singletonMap("pipeline", prettyPrint.toJson(pipeline))));
 

--- a/src/com.tw.go.config.json/ParsedRequest.java
+++ b/src/com.tw.go.config.json/ParsedRequest.java
@@ -85,6 +85,20 @@ class ParsedRequest {
         }
     }
 
+    <T> T getParam(String paramName, Class<T> type) {
+        try {
+            JsonElement json = params.get(paramName);
+
+            if (null == json || json.isJsonNull()) {
+                throw new RequestParseException(format(MISSING_PARAM_MESSAGE, paramName, requestName));
+            }
+
+            return GSON.fromJson(json, type);
+        } catch (Exception e) {
+            throw new RequestParseException(format(PARAM_FAILED_TO_PARSE_TO_TYPE, paramName, requestName, e.getMessage()));
+        }
+    }
+
     String getConfigurationKey(String keyName) {
         String value = null;
 

--- a/test/com.tw.go.config.json/JsonConfigPluginTest.java
+++ b/test/com.tw.go.config.json/JsonConfigPluginTest.java
@@ -9,6 +9,7 @@ import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
 import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -255,10 +256,9 @@ public class JsonConfigPluginTest {
 
     @Test
     public void shouldGiveBackPipelineJSONForPipelineExport() throws UnhandledRequestTypeException {
-        HashMap<String, Object> pipeline = new HashMap<String, Object>();
-        pipeline.put("name", "pipeline");
-        pipeline.put("group", "group");
-        pipeline.put("stages", Collections.emptyList());
+        CRPipeline pipeline = new CRPipeline();
+        pipeline.setGroupName("group");
+        pipeline.setName("pipeline");
 
         Gson gson = new Gson();
         String pipelineJson = gson.toJson(pipeline);


### PR DESCRIPTION
This should not be merged until 19.1.0 is merged as the contract won't be released until then. The `goCdVersion` will also need to be updated to 19.1.0

You can test these changes by changing the dependencies to:

```
compileOnly group: 'cd.go.plugin', name: 'go-plugin-config-repo-experimental', version: "19.1.0-8395"
testCompile group: 'cd.go.plugin', name: 'go-plugin-config-repo-experimental', version: "19.1.0-8395"
```

@marques-work @kierarad Feel free to pull this to test if it fixes the issue talked about here: https://github.com/gocd/gocd/issues/5688#issuecomment-454220314