### PR TITLE
Changed JSON keys returned by `get-capabilities` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Changed JSON keys returned by `get-capabilities` call
+
 # 0.3.5 (15 Jan 2019)
 
  * return json from CLI command

--- a/src/com.tw.go.config.json/Capabilities.java
+++ b/src/com.tw.go.config.json/Capabilities.java
@@ -1,7 +1,14 @@
 package com.tw.go.config.json;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
 public class Capabilities {
+    @Expose
+    @SerializedName("supports_pipeline_export")
     private boolean supportsPipelineExport;
+    @Expose
+    @SerializedName("supports_parse_content")
     private boolean supportsParseContent;
 
     public Capabilities() {


### PR DESCRIPTION
The returned JSON uses snake-cased keys, instead of the camel case keys
used earlier.