### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Expected since GoCD v17.12, you need to use `lock_behavior` rather than `enable_
  * `none` - same `enable_pipeline_locking: false`
 
 <a name="display-order-of-pipelines"/>
+
 ### Controlling the display order
 
 When `format_version` is `4` (see [above](#format-version)), the order of display of pipelines on the GoCD dashboard can be influenced by setting the `display_order_weight` property.


### PR DESCRIPTION
Sorry. Made a small typo in the README in my previous PR.

It looks like this:
<hr>
<img width="931" alt="2019_04_04_13-57-03" src="https://user-images.githubusercontent.com/172235/55577419-8e819c80-56e1-11e9-8486-455ea9794eda.png">
<hr>

instead of how it should:

<hr>
<img width="687" alt="2019_04_04_13-56-41" src="https://user-images.githubusercontent.com/172235/55577432-96414100-56e1-11e9-99c7-eecaeb4cd8cb.png">
<hr>
